### PR TITLE
removed load and Pkg.init from installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ Installation
 ------------
 In julia, install the `Debug` package:
 
-    load("pkg.jl")
-    Pkg.init()  # If you haven't done it before
     Pkg.add("Debug")
 
 `Debug` currently requires a julia build from 2012-12-05 or later.


### PR DESCRIPTION
the following two lines are not necessary anymore, I think, Pkg is always visible, and it gets initialized when this is the first Pkg.add ever.

    load("pkg.jl")
    Pkg.init()  # If you haven't done it before

cheers,

rene
