### PR TITLE
Fix deprecations (#59)

### DIFF
--- a/src/attic/2/debug.jl
+++ b/src/attic/2/debug.jl
@@ -210,7 +210,7 @@ function mark_args_pos!(node::INode, pos::Position)
         elseif head === :call
             mark_pos!(args[1], LHS)
             mark_pos!(args[2:end], DEF)            
-        elseif head === :getindex
+        elseif head === :ref
             mark_pos!(args, RHS)
         else
             error("Don't know how to handle $node in pos $pos")

--- a/src/attic/3/debug.jl
+++ b/src/attic/3/debug.jl
@@ -164,7 +164,7 @@ function argtraits(h::Exp, nargs::Int, pos::Position)
         elseif head === :(=);   [pos, RHS]
         elseif head === :tuple; [pos]
         elseif head === :call;  [LHS, DEF]
-        elseif head === :getindex;   [RHS]
+        elseif head === :ref;   [RHS]
         else
             error("Don't know how to handle $head in pos $pos")
         end        


### PR DESCRIPTION
In the massive deletion of deprecated functions when rc1 was released (#59),
`Base.has`, `Base.ref` and `Base.assign` were removed.

I've simply find/replaced them with their replacements (`haskey`, `getindex`
and `setindex!`), so I might very well have introduced new problems here,
but all tests pass and my own debugging was able to progress smoothly (where
it previously broke as soon as I tried to print something).
