### PR TITLE
Updates for julia 0.4

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
 julia 0.3-
+Compat

--- a/src/Graft.jl
+++ b/src/Graft.jl
@@ -8,6 +8,7 @@ module Graft
 using Debug.AST, Debug.Meta, Debug.Analysis, Debug.Runtime
 import Debug.Meta
 export instrument, graft, @localscope
+using Compat
 
 
 # ---- @localscope: returns the Scope instance for the local scope ------------
@@ -55,7 +56,7 @@ function code_scope(scopesym::Symbol, parent, env::Env, syms)
     :(local $scopesym = $(quot(LocalScope))(
         $parent, 
         $(Expr(:typed_dict,
-               :($(quot(Symbol))=>$(quot((Function,Function)))), pairs...)),
+               :($(quot(Symbol))=>$(quot(@compat(Tuple{Function,Function})))), pairs...)),
         $(quot(env))
     ))
 end

--- a/src/Meta.jl
+++ b/src/Meta.jl
@@ -31,9 +31,9 @@ is_function(node::Ex) = is_expr(node, [:function, :->], 2) ||
 const untyped_comprehensions = [:comprehension, :dict_comprehension]
 const typed_comprehensions   = [:typed_comprehension, 
                                 :typed_dict_comprehension]
-const comprehensions = [untyped_comprehensions, typed_comprehensions]
+const comprehensions = [untyped_comprehensions; typed_comprehensions]
 
-const scope_heads = Set([:while, :try, :for, :let, comprehensions...])
+const scope_heads = Set([:while; :try; :for; :let; comprehensions...])
 is_scope_node(ex) = is_expr(ex, scope_heads) || is_function(ex)
 
 # only for Node/Nothing

--- a/test/test_enterleave.jl
+++ b/test/test_enterleave.jl
@@ -34,7 +34,7 @@ macro test_enterleave(ex)
     Debug.code_debug(Debug.Graft.instrument(is_trap, trap, ex))
 end
 
-answers = {
+answers = Any[
     :while, (Enter,:while), (Leave,:while),
     :(=),
     :while,(Enter,:while),:+=,:call,1,:+=,:call,2,:+=,:call,3,(Leave,:while),
@@ -48,7 +48,7 @@ answers = {
     (Leave,:comprehension), [12,13],
     :function,
     :call, (Enter,:function), :call, 9, :call, (Leave,:function), 81
-}
+]
 
 @test_enterleave begin
     while false

--- a/test/test_graft.jl
+++ b/test/test_graft.jl
@@ -56,7 +56,7 @@ end
     @assert q == 8
     
     # test assignment to ref in graft (don't rewrite)
-    a = [1:5]
+    a = [1:5;]
     @graft a[2]  = 45
     @graft a[3] += 1
     @assert isequal(a, [1,45,4,4,5])

--- a/test/test_step.jl
+++ b/test/test_step.jl
@@ -24,7 +24,7 @@ macro test_step(ex)
     Debug.code_debug(Flow.instrument(trap, ex))
 end
 
-const instructions = {
+const instructions = Any[
     (1, stepover!),
     (2, singlestep!), (3, singlestep!), (4, singlestep!),
     (6, stepover!), (9, stepover!),
@@ -41,7 +41,7 @@ const instructions = {
     (42, stepover!),
     (43, singlestep!), (39, stepout!),
     (44, continue!),
-}
+]
 
 @test_step let
     @bp         #  1


### PR DESCRIPTION
The first commit fixes an error; it was unfortunately difficult to find, as the only error message was
```jl
ERROR: LoadError: TypeError: apply_type: in Dict, expected Type{T}, got Tuple{DataType,DataType}
 in include at ./boot.jl:250 (repeats 2 times)
 in include_from_node1 at ./loading.jl:129
while loading /home/tim/.julia/v0.4/Debug/test/test_graft.jl, in expression starting on line 42
```

The second commit just fixes some deprecations. It's worth pointing out that this introduces a dependency on the `Compat` package.
