### PR TITLE
use __precompile__(true) for good measure

### DIFF
--- a/src/Debug.jl
+++ b/src/Debug.jl
@@ -1,4 +1,4 @@
-isdefined(Main, :__precompile__) && __precompile__()
+isdefined(Main, :__precompile__) && __precompile__(true)
 
 module Debug
 


### PR DESCRIPTION
and to work around https://github.com/JuliaLang/Compat.jl/pull/153
